### PR TITLE
Fix link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Video: https://youtu.be/7pEuoxmb-MI
 
 ## About the Dataset
 
-PartNet is part of the ShapeNet efforts and we provide the PartNet data downloading instructions on [the ShapeNet official webpage](https://www.shapenet.org/download/parts). You need to become a registered user in order to download the data. Please fill in [this form](https://docs.google.com/forms/d/e/1FAIpQLSetsP7aj-Hy0gvP2FxRT3aTIrc_IMqSqR-5Xl8P3x2awDkQbw/viewform?usp=sf_link) if you have any feedback to us for improving PartNet.
+PartNet is part of the ShapeNet efforts and we provide the PartNet data downloading instructions on [the ShapeNet official webpage](https://shapenet.org/download/parts). You need to become a registered user in order to download the data. Please fill in [this form](https://docs.google.com/forms/d/e/1FAIpQLSetsP7aj-Hy0gvP2FxRT3aTIrc_IMqSqR-5Xl8P3x2awDkQbw/viewform?usp=sf_link) if you have any feedback to us for improving PartNet.
 
 ## Data visualization
 


### PR DESCRIPTION
The secure certificate for https://www.shapenet.org does not appear to be setup properly, but the root domain is.  Change to https://shapenet.org